### PR TITLE
Constrain dispatch to specific action types.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,11 +23,13 @@ export const createMessageDispatcherMiddleware = ({ senderURL, parentURL, target
 
 type MessageRecieverOptions = {
   allowedURLs: string[];
+  allowedTypes?: string[];
 };
 
-export const createMessageRecieverMiddleware = ({ allowedURLs }: MessageRecieverOptions) => {
+export const createMessageRecieverMiddleware = ({ allowedURLs, allowedTypes = [] }: MessageRecieverOptions) => {
   const messageToActionHandler = createMessageToActionHandler({
-    allowedURLs
+    allowedURLs,
+    allowedTypes
   });
 
   return MessageRecieverMiddleware({ messageToActionHandler });

--- a/src/messaging/message-handler.ts
+++ b/src/messaging/message-handler.ts
@@ -18,6 +18,7 @@ const isValidAction = (action: any): boolean => isString(action.type);
 
 type Dependencies = {
   allowedURLs: string[];
+  allowedTypes?: string[];
 }
 
 export type ActionHandler = (action: any) => void;
@@ -26,10 +27,14 @@ export type MessageHandler = (ev: MessageEvent) => void;
 
 export type MessageToActionHandler = (fn: ActionHandler) => MessageHandler;
 
-export const createMessageToActionHandler = ({ allowedURLs }: Dependencies): MessageToActionHandler  => {
+export const createMessageToActionHandler = ({allowedURLs: allowedURLs, allowedTypes: allowedTypes = []}: Dependencies): MessageToActionHandler  => {
 
   const isValidOrigin = (origin: string): boolean => {
     return allowedURLs.some(url => url.includes(origin));
+  };
+
+  const isValidType = (action: string): boolean => {
+      return allowedTypes !== undefined ? allowedTypes.some(type => type.includes(action)) : true;
   };
 
   return (fn: ActionHandler): MessageHandler => (ev: MessageEvent) => {
@@ -37,6 +42,7 @@ export const createMessageToActionHandler = ({ allowedURLs }: Dependencies): Mes
     if (!isValidOrigin(origin)) { return; }
     const action = readAction(ev);
     if (!isValidAction(action)) { return; }
+    if (!isValidType(action)) { return; }
     fn(action);
   };
 };


### PR DESCRIPTION
I'm running into issues when using Redux devtools and need to filter out all the messages the tool sends.  I haven't tested this but what do think of constraining to just the action types expected by an application?